### PR TITLE
Added check for closed connection in ssh.reset() method

### DIFF
--- a/lib/ssh.js
+++ b/lib/ssh.js
@@ -205,7 +205,7 @@ SSH.prototype.start = function(options) {
  */
 SSH.prototype.reset = function(cb) {
     cb = cb || function(){};
-    if (this._c._sock !== undefined && this._c._state!=='closed') {
+    if (this._c._sock !== undefined && this._c._state !== 'closed') {
         var self = this;
         this._c.on('close', function(err) {
             self._c = new Connection();


### PR DESCRIPTION
A trivial check to make sure the connection isn't already closed.

This fixes a weird behaviour we encountered: asynchronous code called in an exit function will be executed _after_ the exit function has finished, thus ssh.end() has been already called and the socket is present but closed. At that point calling ssh.reset() stalls forever because the connection will not emit a new 'close' event.
