### PR TITLE
Passphrase was not required by default

### DIFF
--- a/lib/ssh.js
+++ b/lib/ssh.js
@@ -24,7 +24,6 @@ var SSH = function(config) {
         pass: '',
         timeout: 10000,
         key:  '',
-        passphrase: '',
         baseDir: '',
         agent: '',
         agentForward: ''
@@ -194,28 +193,28 @@ SSH.prototype.start = function(options) {
             readyTimeout: self.timeout
         });
     } else if (!self.pass && self.key) {
-        try {
-            self._c.connect({
-                host: self.host,
-                port: self.port || 22,
-                username: self.user,
-                privateKey: self.key,
-                passphrase: self.passphrase,
-                readyTimeout: self.timeout
-            });
-        } catch (err) {
-            self._c.emit('error', new Error('Incorrect passphrase: ' + err.toString()));
-
-            return this;
-        }
-    } else if (self.pass && self.key) {
         self._c.connect({
             host: self.host,
             port: self.port || 22,
             username: self.user,
-            password: self.pass,
+            privateKey: self.key,
             readyTimeout: self.timeout
         });
+    } else if (self.pass && self.key) {
+            try {
+                self._c.connect({
+                    host: self.host,
+                    port: self.port || 22,
+                    username: self.user,
+                    privateKey: self.key,
+                    passphrase: self.pass,
+                    readyTimeout: self.timeout
+                });
+            } catch (err) {
+                self._c.emit('error', new Error('Incorrect passphrase: ' + err.toString()));
+
+                return this;
+            }
     } else {
         self._c.connect({
             host: self.host,


### PR DESCRIPTION
Recent issue came up in which it would be required to use a passphrase for ssh key by default. Instead of having it in use when no password is available, when password (aka "passphrase") and ssh key are available, it would treat the password as a passphrase for the ssh key. This is also a possible fix for #22 as I had the same issue too. 