### PR TITLE
"passphrase" config is now used

### DIFF
--- a/lib/ssh.js
+++ b/lib/ssh.js
@@ -204,14 +204,14 @@ SSH.prototype.start = function(options) {
             privateKey: self.key,
             readyTimeout: self.timeout
         });
-    } else if (self.pass && self.key) {
+    } else if ((self.passphrase || self.pass) && self.key) {
             try {
                 self._c.connect({
                     host: self.host,
                     port: self.port || 22,
                     username: self.user,
                     privateKey: self.key,
-                    passphrase: self.pass,
+                    passphrase: self.passphrase || self.pass,
                     readyTimeout: self.timeout
                 });
             } catch (err) {


### PR DESCRIPTION
Use the config param "passphrase" as mentioned in the Readme but keep working with the "pass" param.