### PR TITLE
Add options.in to exec()

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ ssh.exec('exit 69', {
 }).start();
 ```
 
+* Sending data to stdin:
+
+```javascript
+ssh.exec('cat > /path/to/remote/file', {
+   in: fs.readFileSync('/path/to/local/file')
+}).start();
+```
+
 * Chaining commands together:
 
 ```javascript
@@ -176,6 +184,7 @@ ssh
     * **command** { _String_ }: Command to be executed
     * **options** { _Object_ }:
         * **options.args** { _String[]_ }: Additional command line arguments (default: `null`)
+        * **options.in** { _String_ }: Input to be sent to `stdin`
         * **options.out** { _Function( stdout )_ }: `stdout` handler
             * **stdout** { _String_ }: Output streamed through `stdout`
         * **options.err** { _Function( stderr )_ }: `stderr` handler

--- a/lib/ssh.js
+++ b/lib/ssh.js
@@ -120,6 +120,7 @@ SSH.prototype._queueCommand = function(index) {
                 self._c.end();
             }
         });
+        if (command.in) stream.end(command.in);
     });
 };
 
@@ -138,6 +139,7 @@ SSH.prototype.exec = function(command, options) {
     options = extend({
         args: null,
         start: function(){},
+        in:   null,
         out:  function(){},
         err:  function(){},
         exit: function(){},
@@ -151,6 +153,7 @@ SSH.prototype.exec = function(command, options) {
 
     this._commands.push({
         cmd: command,
+        in:   options.in,
         handlers: {
             start: options.start,
             out:  options.out,

--- a/test/ssh.js
+++ b/test/ssh.js
@@ -100,6 +100,17 @@ describe('SSH', function() {
                 }
             }).start();
         });
+        
+        it('should provide data on stdin', function(done) {
+            var input = 'The quick brown fox\njumps over the lazy dog.\n';
+            ssh.exec('cat', {
+                in: input,
+                out: function(stdout) {
+                    expect(stdout).to.be(input);
+                    done();
+                }
+            }).start();
+        });
 
         it('should handle multiple commands', function(done) {
             ssh


### PR DESCRIPTION
simple-ssh is marvelously easy to use; however it doesn't offer any way to pass data to `stdin`. This PR fixes that problem. :smile: 