### PR TITLE
Fix problem where ready is called multiple times

### DIFF
--- a/lib/ssh.js
+++ b/lib/ssh.js
@@ -192,8 +192,9 @@ SSH.prototype.start = function(options) {
 
     self._c.on('error', options.fail);
 
-    self._c.on('ready', function() {
+    function ready() {
         self._c.removeListener('error', options.fail);
+        self._c.removeListener('ready', ready);
         options.success();
 
         if (self._commands.length > 0) {
@@ -201,7 +202,8 @@ SSH.prototype.start = function(options) {
         } else {
             self._c.end();
         }
-    });
+    }
+    self._c.on('ready', ready);
     if (self.pass && !self.key) {
         self._c.connect({
             host: self.host,


### PR DESCRIPTION
Fix problem where ready is called multiple times because the listener is not getting removed after its called.

This caused some issues whilst running .start multiple times